### PR TITLE
applet.benchmark: Skip going through the MODE state

### DIFF
--- a/software/glasgow/applet/benchmark/__init__.py
+++ b/software/glasgow/applet/benchmark/__init__.py
@@ -48,7 +48,7 @@ class BenchmarkSubtarget(Module):
                 in_fifo.din.eq(self.lfsr.value[8:16]),
                 in_fifo.we.eq(1),
                 self.lfsr.ce.eq(1),
-                NextState("MODE")
+                NextState("SOURCE-1")
             )
         )
         self.fsm.act("SINK-1",
@@ -67,7 +67,7 @@ class BenchmarkSubtarget(Module):
                 ),
                 out_fifo.re.eq(1),
                 self.lfsr.ce.eq(1),
-                NextState("MODE")
+                NextState("SINK-1")
             )
         )
 


### PR DESCRIPTION
I get the feeling that there's a reason that we're going through the MODE state but I can't figure out why. If there isn't a reason, feel free to pull this otherwise just close it!

This improves the throughput a bit.

(before)
  I: glasgow.applet.benchmark: mode source: 16.999 MiB/s
  I: glasgow.applet.benchmark: mode sink: 18.138 MiB/s
(after)
  I: glasgow.applet.benchmark: mode source: 23.196 MiB/s
  I: glasgow.applet.benchmark: mode sink: 23.840 MiB/s