### PR TITLE
applet.program_ice40: remove manual chunked writes

### DIFF
--- a/software/glasgow/applet/program_ice40/__init__.py
+++ b/software/glasgow/applet/program_ice40/__init__.py
@@ -152,12 +152,8 @@ class ProgramICE40Applet(GlasgowApplet, name="program-ice40"):
         iface = await device.demultiplexer.claim_interface(self, self.mux_interface, args)
 
         bitstream = args.bitstream.read()
-        while len(bitstream) > 0:
-            chunk = bitstream[:255]
-            bitstream = bitstream[255:]
-            await iface.write([len(chunk)])
-            await iface.write(chunk)
-        await iface.write([0])
+        await iface.write(bitstream)
+        await iface.write(b'\x00')
         await iface.flush()
 
         # TODO: do this nicely


### PR DESCRIPTION
The previous code didn't build anymore. This was because we tried to
write [0] which isn't supported anymore because of the memoryview()
usage. Perhaps that should be fixed instead?

support.chunked_fifo implements the chunked writes instead now.