### PR TITLE
access.direct.demultiplexer: fix TypeError when length is None

### DIFF
--- a/software/glasgow/access/direct/demultiplexer.py
+++ b/software/glasgow/access/direct/demultiplexer.py
@@ -109,7 +109,8 @@ class DirectDemultiplexerInterface(AccessDemultiplexerInterface):
         # Always try to allocate at least as many USB buffers as the amount of data we know we're
         # going to read from the FIFO. The real value is capped to avoid hitting platform-specific
         # limits for USB I/O size (see above).
-        hint = max(hint, length)
+        if length is not None:
+            hint = max(hint, length)
 
         if len(self._buffer_out) > 0:
             # Flush the buffer, so that everything written before the read reaches the device.


### PR DESCRIPTION
I was getting the following when trying to run the uart applet under python 3.6.7:

```
$ glasgow run uart -V 5 tty
I: glasgow.device.hardware: device already has bitstream ID 5c5871f65cca35e67771380378527bd9
I: glasgow.cli: running handler for applet 'uart'
I: glasgow.applet.uart: port(s) A, B voltage set to 5.0 V
I: glasgow.applet.uart: running on a TTY; enter `Ctrl+\ q` to quit
Traceback (most recent call last):
  File "/usr/local/bin/glasgow", line 11, in <module>
    load_entry_point('glasgow==0.1', 'console_scripts', 'glasgow')()
  File "/usr/local/lib/python3.6/dist-packages/glasgow-0.1-py3.6.egg/glasgow/cli.py", line 662, in main
    exit(loop.run_until_complete(_main()))
  File "/usr/lib/python3.6/asyncio/base_events.py", line 473, in run_until_complete
    return future.result()
  File "/usr/local/lib/python3.6/dist-packages/glasgow-0.1-py3.6.egg/glasgow/cli.py", line 471, in _main
    await task
  File "/usr/local/lib/python3.6/dist-packages/glasgow-0.1-py3.6.egg/glasgow/cli.py", line 461, in run_applet
    await applet.interact(device, args, iface)
  File "/usr/local/lib/python3.6/dist-packages/glasgow-0.1-py3.6.egg/glasgow/applet/uart/__init__.py", line 171, in interact
    await self._interact_tty(uart, args.stream)
  File "/usr/local/lib/python3.6/dist-packages/glasgow-0.1-py3.6.egg/glasgow/applet/uart/__init__.py", line 159, in _interact_tty
    quit_sequence=True, stream=stream)
  File "/usr/local/lib/python3.6/dist-packages/glasgow-0.1-py3.6.egg/glasgow/applet/uart/__init__.py", line 128, in _forward
    data = await uart_fut
  File "/usr/local/lib/python3.6/dist-packages/glasgow-0.1-py3.6.egg/glasgow/access/direct/demultiplexer.py", line 112, in read
    hint = max(hint, length)
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```