### PR TITLE
applet.jtag_svf: Add compatibility SVF generated by Project Trellis

### DIFF
--- a/software/glasgow/applet/jtag/__init__.py
+++ b/software/glasgow/applet/jtag/__init__.py
@@ -334,6 +334,10 @@ class JTAGInterface:
             await self.shift_tms("01100")
         elif self._state in ("Run-Test/Idle", "Update-IR", "Update-DR"):
             await self.shift_tms("1100")
+        elif self._state in ("Pause-DR"):
+            await self.shift_tms("111100")
+        elif self._state in ("Pause-IR"):
+            await self.shift_tms("10")
         else:
             assert False
         self._state = "Shift-IR"
@@ -368,6 +372,10 @@ class JTAGInterface:
             await self.shift_tms("0100")
         elif self._state in ("Run-Test/Idle", "Update-IR", "Update-DR"):
             await self.shift_tms("100")
+        elif self._state in ("Pause-IR"):
+            await self.shift_tms("11100")
+        elif self._state in ("Pause-DR"):
+            await self.shift_tms("10")
         else:
             assert False
         self._state = "Shift-DR"

--- a/software/glasgow/applet/jtag_svf/__init__.py
+++ b/software/glasgow/applet/jtag_svf/__init__.py
@@ -133,7 +133,7 @@ class JTAGSVFInterface(SVFEventHandler):
         if run_clock != "TCK":
             raise GlasgowAppletError("RUNTEST clock %s is not supported" % run_count)
         if run_count is None or min_time is not None and run_count / self._frequency < min_time:
-            run_count = self._frequency * min_time
+            run_count = int(self._frequency * min_time)
         if max_time is not None and run_count / self._frequency > max_time:
             self._logger.warning("RUNTEST exceeds maximum time: %d cycles (%.3f s) > %.3f s"
                                  % (run_count, run_count / self._frequency, max_time))


### PR DESCRIPTION
I've been trying to program a bitstream generated by Project Trellis's bit_to_svf script. 

A few changes were needed to the jtag_svf applet.
 * Support for exiting from Pause-DR/Pause-IR states.
 * Cast the calculated pulse count for RUNTEST to an int when the value was read by the lexer as a float.
Example: `RUNTEST	IDLE	2 TCK	1E-2 SEC;`

With these changes I've been able to successfully load a bitstream into an ECP5 using Glasgow.