### PR TITLE
protocol.jtag_svf: Support multiline literal values.

### DIFF
--- a/software/glasgow/protocol/jtag_svf.py
+++ b/software/glasgow/protocol/jtag_svf.py
@@ -18,10 +18,6 @@ def _hex_to_bitarray(input_nibbles):
     bits.bytereverse()
     return bits
 
-def _scrub_newlines(input_string):
-    regexp = re.compile(r"\s", re.M)
-    return regexp.sub(lambda m: "", input_string)
-
 
 _commands = (
     "ENDDR", "ENDIR", "FREQUENCY", "HDR", "HIR", "PIO", "PIOMAP", "RUNTEST",
@@ -82,8 +78,8 @@ class SVFLexer:
          lambda m: int(m[1])),
         (r"(\d+(?:\.\d+)?(?:E[+-]?\d+)?)",
          lambda m: float(m[1])),
-        (r"\(\s*(([0-9A-F]|(?:((\n\s*|\r\n\s*)?)))+)\s*\)",  # Match Literals over newlines (with possible alignment whitespace)
-         lambda m: _hex_to_bitarray(_scrub_newlines(m[1]))), # Strip out the newlines and whitespace before converting to bitarray
+        (r"\(\s*([0-9A-F\s]+)\s*\)",
+         lambda m: _hex_to_bitarray(re.sub(r"\s+", "", m[1]))),
         (r"\(\s*(.+?)\s*\)",
          lambda m: (m[1],)),
         (r"\Z",


### PR DESCRIPTION
One more change when supporting the SVF files produced by project Trellis's bit_to_svf.

* newline added inside of literals exceeding length ~100 cols.
* potential whitespace present after the newline to aid with formatting.

These are two examples from the SVF I'm working with:
```
SDR	510	TDI  (3FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
             FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
```

```
SDR 8000 TDI (0000000000000000000000FFDFD30000000000000000000000200000000000000000000000000000000000
000000000200000200040000000000000000000000000008000000000000000000000020000000000000000000FF5C890000
0000000000000000000000000000000000000000000000000000002000000000800000000000000000100000400200000000
00000200000000000020000000000000000000000000FFD1680000000000000000000001A000000018000000000000006000
... continued ...
```

I've added some additional basic test-cases and altered the regular expression in the lexer to find literals like this and remove potential whitespace. 