### PR TITLE
BMP280 datasheet url changed

### DIFF
--- a/software/glasgow/applet/sensor/bmp280/__init__.py
+++ b/software/glasgow/applet/sensor/bmp280/__init__.py
@@ -1,4 +1,4 @@
-# BMP280 reference: https://ae-bst.resource.bosch.com/media/_tech/media/datasheets/BST-BMP280-DS001-19.pdf
+# BMP280 reference: https://ae-bst.resource.bosch.com/media/_tech/media/datasheets/BST-BMP280-DS001.pdf
 
 import logging
 import asyncio


### PR DESCRIPTION
URL didn't work, looks like they dropped the revision number from the filenames.